### PR TITLE
Circular fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: ruby
 rvm:
 - 1.9.3
 - 2.0.0
-- 2.2.0
+- 2.2.1
 - ruby-head
 env:
   matrix:
-  - RAILS_VERSION=4.1.0
-  - RAILS_VERSION=4.2.0
+  - RAILS_VERSION=4.1.10
+  - RAILS_VERSION=4.2.1
   global:
   - secure: qXpWydxv6DHMrvGL8WH4wNRY4MTY7KV/x308Y5dHkZCrI7k9UOccvznp69KT3Z+tzYEFDXfUix5wA6pgyVcvrsQyiLSjGcyzHhxJKs1gk0gcxAkmhwHmUP9aiXWUe/mzpj7Uoc2DHwpPTpK1wQ5kV6eV+jzQLuN3nhfNr2sL8b4=
 script: bundle exec rake test

--- a/lib/poly_belongs_to/dup.rb
+++ b/lib/poly_belongs_to/dup.rb
@@ -22,7 +22,7 @@ module PolyBelongsTo
               child.respond_to?(:build) ? child.each {|spawn|
                 builder.pbt_deep_dup_build(spawn) {singleton_record}
               } : builder.pbt_deep_dup_build(child) {singleton_record}
-          end unless singleton_record.flagged?(item_to_build_on)
+          end unless singleton_record.include?(item_to_build_on)
         end
         item_to_build_on       
       end

--- a/lib/poly_belongs_to/singleton_set.rb
+++ b/lib/poly_belongs_to/singleton_set.rb
@@ -26,6 +26,10 @@ module PolyBelongsTo
       add?(record)
     end
 
+    def include?(record)
+      @set.include?(formatted_name(record))
+    end
+
     def flag(record)
       @flagged << formatted_name(record)
     end

--- a/test/dummy/app/models/alpha.rb
+++ b/test/dummy/app/models/alpha.rb
@@ -1,0 +1,4 @@
+class Alpha < ActiveRecord::Base
+  belongs_to :delta
+  has_many :betas
+end

--- a/test/dummy/app/models/beta.rb
+++ b/test/dummy/app/models/beta.rb
@@ -1,0 +1,4 @@
+class Beta < ActiveRecord::Base
+  belongs_to :alpha
+  has_many :capas
+end

--- a/test/dummy/app/models/capa.rb
+++ b/test/dummy/app/models/capa.rb
@@ -1,0 +1,4 @@
+class Capa < ActiveRecord::Base
+  belongs_to :beta
+  has_many :deltas
+end

--- a/test/dummy/app/models/delta.rb
+++ b/test/dummy/app/models/delta.rb
@@ -1,0 +1,4 @@
+class Delta < ActiveRecord::Base
+  belongs_to :capa
+  has_many :alphas
+end

--- a/test/dummy/db/migrate/20150322233720_create_alphas.rb
+++ b/test/dummy/db/migrate/20150322233720_create_alphas.rb
@@ -1,0 +1,10 @@
+class CreateAlphas < ActiveRecord::Migration
+  def change
+    create_table :alphas do |t|
+      t.string :content
+      t.references :delta, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20150322233733_create_beta.rb
+++ b/test/dummy/db/migrate/20150322233733_create_beta.rb
@@ -1,0 +1,10 @@
+class CreateBeta < ActiveRecord::Migration
+  def change
+    create_table :beta do |t|
+      t.string :content
+      t.references :alpha, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20150322233743_create_capas.rb
+++ b/test/dummy/db/migrate/20150322233743_create_capas.rb
@@ -1,0 +1,10 @@
+class CreateCapas < ActiveRecord::Migration
+  def change
+    create_table :capas do |t|
+      t.string :content
+      t.references :beta, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20150322233755_create_delta.rb
+++ b/test/dummy/db/migrate/20150322233755_create_delta.rb
@@ -1,0 +1,10 @@
+class CreateDelta < ActiveRecord::Migration
+  def change
+    create_table :delta do |t|
+      t.string :content
+      t.references :capa, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150301100722) do
+ActiveRecord::Schema.define(version: 20150322233755) do
 
   create_table "addresses", force: true do |t|
     t.integer  "addressable_id"
@@ -22,6 +22,33 @@ ActiveRecord::Schema.define(version: 20150301100722) do
   end
 
   add_index "addresses", ["addressable_id", "addressable_type"], name: "index_addresses_on_addressable_id_and_addressable_type"
+
+  create_table "alphas", force: true do |t|
+    t.string   "content"
+    t.integer  "delta_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "alphas", ["delta_id"], name: "index_alphas_on_delta_id"
+
+  create_table "beta", force: true do |t|
+    t.string   "content"
+    t.integer  "alpha_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "beta", ["alpha_id"], name: "index_beta_on_alpha_id"
+
+  create_table "capas", force: true do |t|
+    t.string   "content"
+    t.integer  "beta_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "capas", ["beta_id"], name: "index_capas_on_beta_id"
 
   create_table "cars", force: true do |t|
     t.integer  "user_id"
@@ -40,6 +67,15 @@ ActiveRecord::Schema.define(version: 20150301100722) do
   end
 
   add_index "contacts", ["user_id"], name: "index_contacts_on_user_id"
+
+  create_table "delta", force: true do |t|
+    t.string   "content"
+    t.integer  "capa_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "delta", ["capa_id"], name: "index_delta_on_capa_id"
 
   create_table "geo_locations", force: true do |t|
     t.integer  "address_id"

--- a/test/dup_test.rb
+++ b/test/dup_test.rb
@@ -67,11 +67,12 @@ class DupTest < ActiveSupport::TestCase
       alpha2 = Alpha.new( CleanAttrs[alpha] )
       CleanAttrs[alpha2].must_equal CleanAttrs[alpha]
       alpha2.pbt_deep_dup_build(beta)
+      #CleanAttrs[alpha2.betas.first].must_equal "asdf"
       #alpha2.save
       CleanAttrs[alpha2.betas.first].must_equal CleanAttrs[beta]
       CleanAttrs[alpha2.betas.first.capas.first].must_equal CleanAttrs[capa]
       CleanAttrs[alpha2.betas.first.capas.first.deltas.first].must_equal CleanAttrs[delta]
-      CleanAttrs[alpha2.betas.first.capas.first.deltas.firsti.alphas.first].must_be_nil
+      CleanAttrs[alpha2.betas.first.capas.first.deltas.first.alphas.first].wont_equal CleanAttrs[alpha]
     end
   end
 end

--- a/test/dup_test.rb
+++ b/test/dup_test.rb
@@ -51,7 +51,7 @@ class DupTest < ActiveSupport::TestCase
     end
   end
 
-  describe "handles circular references like a champ!" do
+  describe "PolyBelongsTo::Dup #pbt_deep_dup_build handles circular references like a champ!" do
     alpha = Alpha.new; alpha.save
     beta = alpha.betas.build; beta.save
     capa = beta.capas.build; capa.save
@@ -67,12 +67,11 @@ class DupTest < ActiveSupport::TestCase
       alpha2 = Alpha.new( CleanAttrs[alpha] )
       CleanAttrs[alpha2].must_equal CleanAttrs[alpha]
       alpha2.pbt_deep_dup_build(beta)
-      #CleanAttrs[alpha2.betas.first].must_equal "asdf"
-      #alpha2.save
       CleanAttrs[alpha2.betas.first].must_equal CleanAttrs[beta]
       CleanAttrs[alpha2.betas.first.capas.first].must_equal CleanAttrs[capa]
       CleanAttrs[alpha2.betas.first.capas.first.deltas.first].must_equal CleanAttrs[delta]
-      CleanAttrs[alpha2.betas.first.capas.first.deltas.first.alphas.first].wont_equal CleanAttrs[alpha]
+      CleanAttrs[alpha2.betas.first.capas.first.deltas.first.alphas.first].must_equal CleanAttrs[alpha]
+      alpha2.betas.first.capas.first.deltas.first.alphas.first.betas.first.must_be_nil
     end
   end
 end

--- a/test/dup_test.rb
+++ b/test/dup_test.rb
@@ -28,7 +28,6 @@ class DupTest < ActiveSupport::TestCase
       bob_prof = profiles(:bob_prof)
       contact = user1.contacts.new
       contact.pbt_deep_dup_build(bob_prof)
-      contact.profile = contact.profile
       CleanAttrs[contact.profile                                                        ].
         must_equal CleanAttrs[bob_prof]
       CleanAttrs[contact.profile.addresses.first                                        ].
@@ -49,6 +48,30 @@ class DupTest < ActiveSupport::TestCase
         must_equal CleanAttrs[bob_prof.phones.last]
       CleanAttrs[contact.profile.photo                                                  ].
         must_equal CleanAttrs[bob_prof.photo]
+    end
+  end
+
+  describe "handles circular references like a champ!" do
+    alpha = Alpha.new; alpha.save
+    beta = alpha.betas.build; beta.save
+    capa = beta.capas.build; capa.save
+    delta = capa.deltas.build; delta.save
+    alpha.update(delta_id: delta.id)
+    it "is a circle" do
+      alpha.pbt_parent.must_equal delta
+      beta.pbt_parent.must_equal alpha
+      capa.pbt_parent.must_equal beta
+      delta.pbt_parent.must_equal capa
+    end
+    it "clones without duplicating cirular reference" do
+      alpha2 = Alpha.new( CleanAttrs[alpha] )
+      CleanAttrs[alpha2].must_equal CleanAttrs[alpha]
+      alpha2.pbt_deep_dup_build(beta)
+      #alpha2.save
+      CleanAttrs[alpha2.betas.first].must_equal CleanAttrs[beta]
+      CleanAttrs[alpha2.betas.first.capas.first].must_equal CleanAttrs[capa]
+      CleanAttrs[alpha2.betas.first.capas.first.deltas.first].must_equal CleanAttrs[delta]
+      CleanAttrs[alpha2.betas.first.capas.first.deltas.firsti.alphas.first].must_be_nil
     end
   end
 end

--- a/test/singleton_set_test.rb
+++ b/test/singleton_set_test.rb
@@ -25,6 +25,11 @@ class DupTest < ActiveSupport::TestCase
       the_set.to_a.must_equal ["#{example.class.name}-#{example.id}"]
     end
 
+    it "can tell you what's included" do
+      the_set.<<(example)
+      the_set.include?(example).must_be_same_as true
+    end
+
     it "flags a duplicate" do
       the_set.<<(example)
       the_set.<<(example).must_be_nil


### PR DESCRIPTION
Found Rails' plurality isn't always plural.  Performed rewrite for that.  Duplication now handles circular references well.